### PR TITLE
fix: querying for semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Accessed by typing the following:
 `api.itwewina.altlab.dev/api/search/?wn_synset=<synset>` where <synset> is a string. 
 Returns all objects where the WordNet synsets contains or matches the string provided. 
 Return type is JSON.
+**Note:** There **must** be a space between the last word of the synset and 
+the number of the synset. For example: `(n) dog 1` (with spaces, just like that) 
+is correct. Incorrect variants include: `(n) dog1` and `(n) dog#1`.
 
 ### rapidwords
 In this option, you route to the `rapidwords` endpoint. It has one required argument.

--- a/src/API/search/lookup.py
+++ b/src/API/search/lookup.py
@@ -38,11 +38,19 @@ def fetch_results(search_run: core.SearchRun):
     if search_run.rw_index or search_run.rw_domain or search_run.wn_synset:
         filters = []
         if search_run.rw_domain:
-            filters.append(Q(rw_domains__contains=f" {search_run.rw_domain};"))
+            filters.append(Q(rw_domains__icontains=f" {search_run.rw_domain};"))
         if search_run.rw_index:
-            filters.append(Q(rw_indices__contains=f" {search_run.rw_index};"))
+            filters.append(Q(rw_indices__icontains=f" {search_run.rw_index};"))
         if search_run.wn_synset:
-            filters.append(Q(wn_synsets__contains=f" {search_run.wn_synset};"))
+            search_synset_list = search_run.wn_synset.split(' ')
+            search_synset_list[-1] = "#" + search_synset_list[-1]
+            search_synset = ""
+            for i, s in enumerate(search_synset_list):
+                search_synset += s
+                if i < len(search_synset_list) - 2:
+                    search_synset += ' '
+
+            filters.append(Q(wn_synsets__icontains=f"{search_synset}"))
         db_matches = list(Wordform.objects.filter(reduce(operator.or_, filters)))
 
     for wf in db_matches:

--- a/src/lexicon/management/commands/fixsemantics.py
+++ b/src/lexicon/management/commands/fixsemantics.py
@@ -1,0 +1,18 @@
+from django.core.management import BaseCommand
+from lexicon.models import RapidWords, Wordform
+from tqdm import tqdm
+
+
+class Command(BaseCommand):
+    help = """Add a leading space and a trailing semicolon to all semantic entries"""
+
+    def handle(self, **options):
+        words = Wordform.objects.all()
+        for word in tqdm(words):
+            if word.rw_indices:
+                word.rw_indices = " " + word.rw_indices + ";"
+            if word.rw_domains:
+                word.rw_domains = " " + word.rw_domains + ";"
+            if word.wn_synsets:
+                word.wn_synsets = " " + word.wn_synsets + ";"
+            word.save()

--- a/src/views.py
+++ b/src/views.py
@@ -192,10 +192,11 @@ def semantic_api(request):
     if query:
         context["query"] = query
         if '.' in query:
-            rw = RapidWords.objects.get(index=query)
+            rw = RapidWords.objects.filter(index=query).first()
         else:
-            rw = RapidWords.objects.get(domain=query)
+            rw = RapidWords.objects.filter(domain=query).first()
         if not rw:
+            context["response"] = "No results found"
             return Response(context)
 
         context["class"] = f"{rw.index} {rw.domain}"
@@ -204,6 +205,7 @@ def semantic_api(request):
         context["hypernyms"] = rw.hypernyms
         context["hyponyms"] = rw.hyponyms
 
+    context["message"] = "Positional argument 'q' required"
     return Response(context)
 
 


### PR DESCRIPTION
## What's in this PR:

- can query the rapidwords endpoint and not get results without crashing
- can query specific semantic fields for an entry
- can query with a number on the end of a wn_synset and get relevant results